### PR TITLE
Valid emails must be bu.edu/subdomain.bu.edu

### DIFF
--- a/app.js
+++ b/app.js
@@ -293,7 +293,7 @@ app.get("/login/fail", (req, res) => res.status(401).send("Login failed"));
 
 const validEmail = email => {
   // eslint-disable-next-line
-  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((bu\.edu)|(([a-zA-Z\-0-9]+\.)bu\.edu))$/;
   return re.test(String(email).toLowerCase());
 };
 


### PR DESCRIPTION
Change regEX to make sure emails being registered come either from a email@bu.edu or email@subdomain.bu.edu

Although this won't be an issue for creating accounts that come from the SSO, it does become an issue while creating user docs via the website, since the generateUID function doesn't necessarily need a bu domain, which could lead to issues.